### PR TITLE
Add rate limiting and lifespan HTTP clients

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,13 +22,7 @@ ALLOW_ORIGINS=*
 ENVIRONMENT=development
 LOG_LEVEL=info
 
-# Database
-POSTGRES_PORT=5432
-POSTGRES_DB=moodleng
-POSTGRES_USER=moodleng
-POSTGRES_PASSWORD=moodleng_dev_password
-
-# Full database connection
-DATABASE_URL=postgresql://moodleng:moodleng_dev_password@postgres:5432/moodleng
-
 REDIS_URL=redis://redis:6379/0
+
+# Rate limiting (default: 10 login attempts per minute per IP)
+LOGIN_RATE_LIMIT=10/minute

--- a/compose.yaml
+++ b/compose.yaml
@@ -18,26 +18,6 @@ services:
     networks:
       - moodleng-network
 
-  postgres:
-    image: postgres:16-alpine
-    container_name: MoodleNG-Postgres
-    ports:
-      - "${POSTGRES_PORT:-5432}:5432"
-    environment:
-      - POSTGRES_DB=${POSTGRES_DB:-moodleng}
-      - POSTGRES_USER=${POSTGRES_USER:-moodleng}
-      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-moodleng_dev_password}
-    volumes:
-      - postgres-data:/var/lib/postgresql/data
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-moodleng}"]
-      interval: 10s
-      timeout: 3s
-      retries: 3
-    restart: unless-stopped
-    networks:
-      - moodleng-network
-
   moodleware-api:
     container_name: MoodlewareAPI
     build:
@@ -53,11 +33,8 @@ services:
       - SECRET_KEY=${SECRET_KEY:-cXWIu5Yj5P4TpHNcqwwVrPDqBQTstQF0A3_C_vjM2LQ}
       - SESSION_MAX_AGE=${SESSION_MAX_AGE:-14400}
       - REDIS_URL=${REDIS_URL:-redis://redis:6379/0}
-      - DATABASE_URL=${DATABASE_URL:-postgresql://moodleng:moodleng_dev_password@postgres:5432/moodleng}
     depends_on:
       redis:
-        condition: service_healthy
-      postgres:
         condition: service_healthy
     restart: unless-stopped
     networks:
@@ -69,6 +46,4 @@ networks:
 
 volumes:
   redis-data:
-    driver: local
-  postgres-data:
     driver: local

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ colorlog
 python-dotenv
 itsdangerous
 redis>=5.0.0
+slowapi

--- a/src/mw_utils/limiter.py
+++ b/src/mw_utils/limiter.py
@@ -1,0 +1,9 @@
+from slowapi import Limiter
+from slowapi.util import get_remote_address
+from .env import get_env_variable
+
+# Shared limiter instance – attached to app.state in app.py
+limiter = Limiter(key_func=get_remote_address, default_limits=[])
+
+# Configurable login rate limit; override via LOGIN_RATE_LIMIT env var
+LOGIN_RATE_LIMIT: str = get_env_variable("LOGIN_RATE_LIMIT") or "10/minute"

--- a/src/routes/office_preview.py
+++ b/src/routes/office_preview.py
@@ -23,24 +23,36 @@ router = APIRouter(prefix="/office", tags=["office-preview"])
 TOKEN_PREFIX = "ot_token:"
 TOKEN_EXPIRY_SECONDS = 60
 
-# Persistent HTTP client for connection pooling (shared pattern from files.py)
 _http_client: Optional[httpx.AsyncClient] = None
 
 
-async def get_http_client() -> httpx.AsyncClient:
-    """Get or create persistent HTTP client with connection pooling"""
+async def init_http_client() -> None:
+    """Initialize the persistent HTTP client. Called from app lifespan."""
     global _http_client
-    if _http_client is None or _http_client.is_closed:
-        _http_client = httpx.AsyncClient(
-            timeout=60.0,
-            follow_redirects=True,
-            http2=True,
-            limits=httpx.Limits(
-                max_connections=100,
-                max_keepalive_connections=20,
-                keepalive_expiry=30.0,
-            )
+    _http_client = httpx.AsyncClient(
+        timeout=60.0,
+        follow_redirects=True,
+        http2=True,
+        limits=httpx.Limits(
+            max_connections=100,
+            max_keepalive_connections=20,
+            keepalive_expiry=30.0,
         )
+    )
+
+
+async def close_http_client() -> None:
+    """Close the persistent HTTP client. Called from app lifespan."""
+    global _http_client
+    if _http_client is not None:
+        await _http_client.aclose()
+        _http_client = None
+
+
+def get_http_client() -> httpx.AsyncClient:
+    """Return the lifespan-managed HTTP client."""
+    if _http_client is None:
+        raise RuntimeError("HTTP client not initialized")
     return _http_client
 
 
@@ -193,8 +205,7 @@ async def get_file_with_one_time_token(
         moodle_url = moodle_url.rstrip('/')
         file_url = f"{moodle_url}{file_path}"
         
-        # Fetch file from Moodle with persistent HTTP client
-        client = await get_http_client()
+        client = get_http_client()
         file_content, moodle_headers = await fetch_file_from_moodle(
             file_url,
             moodle_token,

--- a/src/routes/secure_auth.py
+++ b/src/routes/secure_auth.py
@@ -12,6 +12,7 @@ from ..mw_utils.session import (
 )
 from ..mw_utils.env import get_env_variable
 from ..mw_utils.http_client import DEFAULT_HEADERS
+from ..mw_utils.limiter import limiter, LOGIN_RATE_LIMIT
 
 logger = logging.getLogger("moodleware.secure_auth")
 router = APIRouter(prefix="/secure", tags=["Secure Authentication"])
@@ -41,7 +42,8 @@ def _normalize_moodle_url(url: str) -> str:
 
 
 @router.post("/login", response_model=LoginResponse)
-async def secure_login(login_data: LoginRequest, response: Response):
+@limiter.limit(LOGIN_RATE_LIMIT)
+async def secure_login(request: Request, login_data: LoginRequest, response: Response):
     moodle_url = _normalize_moodle_url(
         login_data.moodle_url or get_env_variable("MOODLE_URL") or "https://moodle.example.com"
     )


### PR DESCRIPTION
<!--Before you make this PR, please review the README.md and ensure your changes align with the project goals.-->

## Type of Change
- [x] Refactoring
- [x] Security patch

## Description
<!--[Provide a detailed explanation of the changes you have made. Include the reasons behind these changes and any relevant context. Link any related issues.]-->
- Introduced login rate limiting with slowapi and central Limiter (src/mw_utils/limiter.py), expose LOGIN_RATE_LIMIT env var, and attach middleware/exception handler in app.
- Refactored files and office_preview routes to use lifespan-managed httpx clients (init/close in app.lifespan) to improve connection pooling and resource cleanup.
- Removed Postgres service and DB env vars from compose/.env.example and stop using a local DB connection; keep Redis config.
- Add slowapi to requirements and update secure_auth.login to accept Request and apply the limiter decorator. Misc: remove unused imports and session cleanup task; ensure HTTP clients raise if not initialized.